### PR TITLE
add reason to support wider boycott list

### DIFF
--- a/schemas/brand_schema.yaml
+++ b/schemas/brand_schema.yaml
@@ -22,6 +22,7 @@ properties:
       enum:
         - operations_in_israel
         - operations_in_settlements
+        - other
   countries:
     description: |-
       A list of countries (ISO alpha-2 country codes) that the brand operates in. 

--- a/schemas/brand_schema.yaml
+++ b/schemas/brand_schema.yaml
@@ -22,7 +22,8 @@ properties:
       enum:
         - operations_in_israel
         - operations_in_settlements
-        - other
+        - executive_supports_israel
+        - hiring_discrimination
   countries:
     description: |-
       A list of countries (ISO alpha-2 country codes) that the brand operates in. 

--- a/scripts/validate_yaml.py
+++ b/scripts/validate_yaml.py
@@ -42,9 +42,14 @@ def main():
     company_schema = load_yaml(os.path.join(root_path, "schemas/company_schema.yaml"))
     company_files = glob.glob(os.path.join(root_path, "data/companies/") + "*.yaml")
     print("Validating", len(company_files), "companies")
+    failed = False
     for file in company_files:
         if not validate_with_schema(file, company_schema):
-            exit(1)
+            failed = True
+
+    if failed:
+        exit(1)
+
     print("All companies are valid.")
 
 


### PR DESCRIPTION
Addressing #14 

Adding an `other` option for boycottt reasons outside occupation. Would it be better to add reasons like `ceo_supports_israel`, `opposes_ceasefire`?